### PR TITLE
Formatter and command line changes

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (defproject lein-cucumber "1.0.0.M1-SNAPSHOT"
   :description "Run cucumber-jvm specifications with leiningen"
-  :dependencies [[info.cukes/cucumber-clojure "1.0.0.RC23-SNAPSHOT"]
+  :dependencies [[info.cukes/cucumber-clojure "1.0.0"]
                  [leiningen-core "2.0.0-preview2"]]
   :eval-in :leiningen
   :license {:name "Unlicense"

--- a/src/leiningen/cucumber.clj
+++ b/src/leiningen/cucumber.clj
@@ -4,7 +4,7 @@
 
 (defn cucumber
   "Runs Cucumber features in test/features with glue in test/features/step_definitions"
-  [project]
+  [project & args]
   (let [runtime (gensym "runtime")
         feature-paths (into [] (get project :cucumber-feature-paths ["features"]))
         glue-paths (into [] (map #(str (file % "step_definitions/")) feature-paths))
@@ -16,6 +16,6 @@
                     ['info.cukes/cucumber-clojure "1.0.0.RC23-SNAPSHOT"])
          (update-in [:source-paths] (partial apply conj) glue-paths))
      `(do
-        (let [~runtime (leiningen.cucumber.util/run-cucumber! ~feature-paths ~glue-paths ~target-path)]
+        (let [~runtime (leiningen.cucumber.util/run-cucumber! ~feature-paths ~glue-paths ~target-path ~(vec args))]
           (leiningen.core.main/exit (.exitStatus ~runtime))))
      '(require 'leiningen.cucumber.util 'leiningen.core.main))))

--- a/src/leiningen/cucumber.clj
+++ b/src/leiningen/cucumber.clj
@@ -13,7 +13,7 @@
      (-> project
          (update-in [:dependencies] conj
                     ['lein-cucumber "1.0.0.M1-SNAPSHOT"]
-                    ['info.cukes/cucumber-clojure "1.0.0.RC23-SNAPSHOT"])
+                    ['info.cukes/cucumber-clojure "1.0.0"])
          (update-in [:source-paths] (partial apply conj) glue-paths))
      `(do
         (let [~runtime (leiningen.cucumber.util/run-cucumber! ~feature-paths ~glue-paths ~target-path ~(vec args))]

--- a/src/leiningen/cucumber/util.clj
+++ b/src/leiningen/cucumber/util.clj
@@ -10,8 +10,8 @@
     (make-parents report-file)
     (writer report-file)))
 
-(defn- create-runtime-options [feature-paths glue-paths target-path]
-  (let [runtime-options (RuntimeOptions. (into-array String []))]
+(defn- create-runtime-options [feature-paths glue-paths target-path args]
+  (let [runtime-options (RuntimeOptions. (into-array String args))]
     (.addAll (.featurePaths runtime-options) feature-paths)
     (.addAll (.glue runtime-options) glue-paths)
     (doto (.formatters runtime-options)
@@ -24,8 +24,9 @@
         resource-loader (FileResourceLoader.)]
     (cucumber.runtime.Runtime. resource-loader classloader runtime-options)))
 
-(defn run-cucumber! [feature-paths glue-paths target-path]
-  (let [runtime-options (create-runtime-options feature-paths glue-paths target-path)
+(defn run-cucumber! [feature-paths glue-paths target-path args]
+  (let [runtime-options (create-runtime-options feature-paths glue-paths
+                                                target-path args)
         runtime (create-runtime runtime-options)]
     (.run runtime)
     runtime))

--- a/src/leiningen/cucumber/util.clj
+++ b/src/leiningen/cucumber/util.clj
@@ -12,8 +12,9 @@
 
 (defn- create-runtime-options [feature-paths glue-paths target-path args]
   (let [runtime-options (RuntimeOptions. (into-array String args))]
-    (.addAll (.featurePaths runtime-options) feature-paths)
-    (.addAll (.glue runtime-options) glue-paths)
+    (if (.. runtime-options featurePaths (isEmpty))
+      (.. runtime-options featurePaths (addAll feature-paths)))
+    (.. runtime-options glue (addAll glue-paths))
     (doto (.formatters runtime-options)
       (.add (CucumberPrettyFormatter. (report-writer target-path)))
       (.add (ProgressFormatter. *out*)))


### PR DESCRIPTION
These commits add the progress formatter (so that console output is not empty), pass lein command line arguments into RuntimeOptions, and omit the default feature paths if one is added via the command line.

I've been using this code with cucumber-clojure-1.0.0
