### PR TITLE
upgrade cucumber-jvm to 1.0.14 and leiningen-core to preview10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: clojure
 lein: lein2
-script: lein2 cucumber
+script: lein2 do install, cucumber

--- a/features/cucumber.feature
+++ b/features/cucumber.feature
@@ -3,6 +3,7 @@ Feature: lein-cucumber works
   Scenario: No features
     Given a lein-cucumber project without special configuration
     And no features in the "features" directory
+    And no step definitions in the "features/step_definitions" directory
     When I run lein-cucumber without command line arguments
     Then the output should include "No features found"
 

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (defproject lein-cucumber "1.0.0"
   :description "Run cucumber-jvm specifications with leiningen"
-  :dependencies [[info.cukes/cucumber-clojure "1.0.4"]
-                 [leiningen-core "2.0.0-preview3"]]
+  :dependencies [[info.cukes/cucumber-clojure "1.0.14"]
+                 [leiningen-core "2.0.0-preview10"]]
   :profiles {:test {:dependencies [[commons-io "2.0"]]}}
   :plugins [[lein-cucumber "1.0.0"]]
   :eval-in :leiningen

--- a/src/leiningen/cucumber.clj
+++ b/src/leiningen/cucumber.clj
@@ -15,7 +15,7 @@
       (.. runtime-options glue (addAll glue-paths)))))
 
 (defn create-partial-runtime-options [{:keys [cucumber-feature-paths target-path cucumber-glue-paths] :or {cucumber-feature-paths ["features"]}} args]
-  (let [runtime-options (RuntimeOptions. (into-array String args))]
+  (let [runtime-options (RuntimeOptions. (java.util.Properties.) (into-array String args))]
     (configure-feature-paths runtime-options cucumber-feature-paths)
     (configure-glue-paths runtime-options cucumber-glue-paths (.featurePaths runtime-options))
     runtime-options))
@@ -33,7 +33,7 @@
      (-> project
          (update-in [:dependencies] conj
                     ['lein-cucumber "1.0.0"]
-                    ['info.cukes/cucumber-clojure "1.0.4"])
+                    ['info.cukes/cucumber-clojure "1.0.14"])
          (update-in [:source-paths] (partial apply conj) glue-paths))
      `(do
         (let [~runtime (leiningen.cucumber.util/run-cucumber! ~feature-paths ~glue-paths ~target-path ~(vec args))]

--- a/src/leiningen/cucumber/util.clj
+++ b/src/leiningen/cucumber/util.clj
@@ -11,7 +11,7 @@
     (writer report-file)))
 
 (defn- create-runtime-options [feature-paths glue-paths target-path args]
-  (let [runtime-options (RuntimeOptions. (into-array String args))]
+  (let [runtime-options (RuntimeOptions. (java.util.Properties.) (into-array String args))]
     (when (.. runtime-options featurePaths (isEmpty))
       (.. runtime-options featurePaths (addAll feature-paths)))
     (when (.. runtime-options glue (isEmpty))


### PR DESCRIPTION
Good day,

I've upgraded cucumber-jvm and leiningen.  

In doing so, I've discovered cucumber.io.FileResourceIterable has become less resilient against missing directories passed in glue paths.  Since there was already a step creating a features directory the simplest thing to do was add the same for the features/step_defintions directory.

-Ben Poweski
