### PR TITLE
Upgrade cucumber-clojure to latest version.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ pom.xml.asc
 .lein-failures
 .lein-deps-sum
 /target/
+.nrepl-port

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 pom.xml
+pom.xml.asc
 *jar
 *.swp
 /lib/

--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
-[![Build Status](https://secure.travis-ci.org/nilswloka/lein-cucumber.png)](http://travis-ci.org/nilswloka/lein-cucumber)
+[![Build Status](https://secure.travis-ci.org/punkisdead/lein-cucumber.png)](http://travis-ci.org/punkisdead/lein-cucumber)
 
 # lein-cucumber
 
 This is a leiningen plugin for use with [cucumber-jvm](https://github.com/cucumber/cucumber-jvm).
+This is a fork of [lein-cucumber](http://github.com/nilswloka/lein-cucumber) with more up to date dependencies.
+
+[![Clojars Project](http://clojars.org/org.clojars.punkisdead/lein-cucumber/latest-version.svg)](http://clojars.org/org.clojars.punkisdead/lein-cucumber)
 
 ## Usage
 
-1. Add `[lein-cucumber "1.0.2"]` to `:plugins` in your project.clj
+1. Add `[lein-cucumber "1.0.4"]` to `:plugins` in your project.clj
 2. Run `lein deps` to fetch all dependencies.
 3. Run all Cucumber features with `lein cucumber`
 
@@ -27,24 +30,27 @@ Glue paths are resolved similarily:
 1. Command line options (e.g. `lein cucumber --glue somewhere/my_stepdefs`) override all other settings.
 2. If no command line options for glue paths are given, step definitions will be loaded from `step_definitions/` directories inside your feature directories.
 
+Formatted output
+
+1. Results are only printed to the console unless you specify a formatter
+2. To create an HTML report you can run the plugin with the following command `lein cucumber --plugin html:target/test-reports`
+
 ## Other settings
 
  The following settings are hard-coded into the plugin:
 
-* A summary report will be printed to the console. 
-* The complete report (formatted with `CucumberPrettyFormatter`) will be written to `test-reports/cucumber.out` inside your project's target directory (usually `target/`).
+* A summary report will be printed to the console.
 * Leiningen will exit with the exit status of the cucumber-jvm [runtime](https://github.com/cucumber/cucumber-jvm/blob/master/core/src/main/java/cucumber/runtime/Runtime.java).
 
 See https://github.com/nilswloka/cucumber-jvm/tree/new-clojure-example/examples/clojure_cukes for an example project.
 
 ## Note
 
-If you like lein-cucumber, consider endorsing me at [coderwall](http://coderwall.com/nilswloka): 
+If you like lein-cucumber, consider endorsing me at [coderwall](http://coderwall.com/punkisdead):
 
-[![endorse](http://api.coderwall.com/nilswloka/endorsecount.png)](http://coderwall.com/nilswloka)
+[![endorse](http://api.coderwall.com/punkisdead/endorsecount.png)](http://coderwall.com/punkisdead)
 
 ## Unlicense
-Written by Nils Wloka, 2012. For licensing information, see UNLICENSE.
+Written by Jeremy Anderson, 2015. For licensing information, see UNLICENSE.
 
-Contributions by [Robert P. Levy](https://github.com/rplevy-draker), [Michael van Acken](https://github.com/mva), [Jeroen van Dijk](https://github.com/jeroenvandijk), [Ben Poweski](https://github.com/bpoweski) and [shaolang](https://github.com/shaolang). Please have a look at http://unlicense.org if you plan to contribute.
-
+Please have a look at http://unlicense.org if you plan to contribute.

--- a/features/cucumber.feature
+++ b/features/cucumber.feature
@@ -44,3 +44,10 @@ Feature: lein-cucumber works
     And a step definition in the "foo" directory
     When I run lein-cucumber with arguments "--glue foo"
     Then the step should be executed
+
+  Scenario: Creates an output file 
+    Given a lein-cucumber project without special configuration
+    And a feature in the "features" directory
+    And a step definition in the "features/step_definitions" directory
+    When I run lein-cucumber without command line arguments
+    Then there should be an output file in the "target/test-reports" directory

--- a/features/cucumber.feature
+++ b/features/cucumber.feature
@@ -49,5 +49,12 @@ Feature: lein-cucumber works
     Given a lein-cucumber project without special configuration
     And a feature in the "features" directory
     And a step definition in the "features/step_definitions" directory
-    When I run lein-cucumber without command line arguments
+    When I run lein-cucumber with arguments "--plugin pretty:target/test-reports/cucumber.out"
     Then there should be an output file in the "target/test-reports" directory
+
+  Scenario: Creates an html output file 
+    Given a lein-cucumber project without special configuration
+    And a feature in the "features" directory
+    And a step definition in the "features/step_definitions" directory
+    When I run lein-cucumber with arguments "--plugin html:target/test-reports"
+    Then there should be an html file in the "target/test-reports" directory

--- a/features/step_definitions/cucumber_steps.clj
+++ b/features/step_definitions/cucumber_steps.clj
@@ -92,3 +92,6 @@
 
 (Then #"^there should be an output file in the \"([^\"]*)\" directory$" [arg1]
       (assert (.exists (as-file "target/test_project/target/test-reports/cucumber.out"))))
+
+(Then #"^there should be an html file in the \"([^\"]*)\" directory$" [arg1]
+      (assert (.exists (as-file "target/test_project/target/test-reports/index.html"))))

--- a/features/step_definitions/cucumber_steps.clj
+++ b/features/step_definitions/cucumber_steps.clj
@@ -80,8 +80,15 @@
       (writing-to-result
        (fn [] (apply cucumber (concat (vector (read-project)) (re-seq #"\S+\b" args))))))
 
+(When #"^I run lein-cucumber with default output$" []
+      (cucumber (read-project)))
+
+
 (Then #"^the output should include \"([^\"]*)\"$" [expected-output]
       (assert-output-includes expected-output))
 
 (Then #"^the step should be executed" []
       (assert-output-includes "{{{STEP EXECUTED}}}"))
+
+(Then #"^there should be an output file in the \"([^\"]*)\" directory$" [arg1]
+      (assert (.exists (as-file "target/test_project/target/test-reports/cucumber.out"))))

--- a/project.clj
+++ b/project.clj
@@ -1,10 +1,10 @@
-(defproject lein-cucumber "1.0.2"
+(defproject lein-cucumber "1.0.3"
   :description "Run cucumber-jvm specifications with leiningen"
-  :dependencies [[info.cukes/cucumber-clojure "1.1.1"]
+  :dependencies [[info.cukes/cucumber-clojure "1.1.6"]
                  [leiningen-core "2.0.0"]
                  [org.clojure/clojure "1.5.0-RC3"]]
   :profiles {:cucumber {:dependencies [[commons-io "2.0"]]
-                        :plugins [[lein-cucumber "1.0.2"]]}}
+                        :plugins [[lein-cucumber "1.0.3"]]}}
   :eval-in :leiningen
   :license {:name "Unlicense"
             :url "http://unlicense.org/"

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,6 @@
 (defproject org.clojars.punkisdead/lein-cucumber "1.0.3"
   :description "Run cucumber-jvm specifications with leiningen"
+  :url https://github.com/punkisdead/lein-cucumber
   :dependencies [[info.cukes/cucumber-clojure "1.1.6"]
                  [leiningen-core "2.0.0"]
                  [org.clojure/clojure "1.5.0-RC3"]]

--- a/project.clj
+++ b/project.clj
@@ -1,11 +1,11 @@
-(defproject org.clojars.punkisdead/lein-cucumber "1.0.3"
+(defproject org.clojars.punkisdead/lein-cucumber "1.0.4"
   :description "Run cucumber-jvm specifications with leiningen"
   :url https://github.com/punkisdead/lein-cucumber
-  :dependencies [[info.cukes/cucumber-clojure "1.1.6"]
+  :dependencies [[info.cukes/cucumber-clojure "1.2.0"]
                  [leiningen-core "2.0.0"]
-                 [org.clojure/clojure "1.5.0-RC3"]]
-  :profiles {:cucumber {:dependencies [[commons-io "2.0"]]
-                        :plugins [[org.clojars.punkisdead/lein-cucumber "1.0.3"]]}}
+                 [org.clojure/clojure "1.6.0"]]
+  :profiles {:cucumber {:dependencies [[commons-io "2.4"]]
+                        :plugins [[org.clojars.punkisdead/lein-cucumber "1.0.4"]]}}
   :eval-in :leiningen
   :license {:name "Unlicense"
             :url "http://unlicense.org/"

--- a/project.clj
+++ b/project.clj
@@ -1,10 +1,10 @@
-(defproject lein-cucumber "1.0.3"
+(defproject org.clojars.punkisdead/lein-cucumber "1.0.3"
   :description "Run cucumber-jvm specifications with leiningen"
   :dependencies [[info.cukes/cucumber-clojure "1.1.6"]
                  [leiningen-core "2.0.0"]
                  [org.clojure/clojure "1.5.0-RC3"]]
   :profiles {:cucumber {:dependencies [[commons-io "2.0"]]
-                        :plugins [[lein-cucumber "1.0.3"]]}}
+                        :plugins [[org.clojars.punkisdead/lein-cucumber "1.0.3"]]}}
   :eval-in :leiningen
   :license {:name "Unlicense"
             :url "http://unlicense.org/"

--- a/src/leiningen/cucumber.clj
+++ b/src/leiningen/cucumber.clj
@@ -5,19 +5,19 @@
   (:import [cucumber.runtime RuntimeOptions]))
 
 (defn- configure-feature-paths [runtime-options feature-paths]
-  (when (.. runtime-options featurePaths (isEmpty))
-    (.. runtime-options featurePaths (addAll feature-paths))))
+  (when (.. runtime-options (getFeaturePaths) (isEmpty))
+    (.. runtime-options (getFeaturePaths) (addAll feature-paths))))
 
 (defn- configure-glue-paths [runtime-options glue-paths feature-paths]
-  (when (.. runtime-options glue (isEmpty))
+  (when (.. runtime-options (getGlue) (isEmpty))
     (if (empty? glue-paths)
-      (.. runtime-options glue (addAll (into [] (map #(str (file % "step_definitions/")) feature-paths))))
-      (.. runtime-options glue (addAll glue-paths)))))
+      (.. runtime-options (getGlue) (addAll (into [] (map #(str (file % "step_definitions/")) feature-paths))))
+      (.. runtime-options (getGlue) (addAll glue-paths)))))
 
 (defn create-partial-runtime-options [{:keys [cucumber-feature-paths target-path cucumber-glue-paths] :or {cucumber-feature-paths ["features"]}} args]
-  (let [runtime-options (RuntimeOptions. (java.util.Properties.) (into-array String args))]
+  (let [runtime-options (RuntimeOptions. (vec args))]
     (configure-feature-paths runtime-options cucumber-feature-paths)
-    (configure-glue-paths runtime-options cucumber-glue-paths (.featurePaths runtime-options))
+    (configure-glue-paths runtime-options cucumber-glue-paths (.getFeaturePaths runtime-options))
     runtime-options))
 
 (defn cucumber
@@ -26,15 +26,15 @@
   (binding [leiningen.core.main/*exit-process?* true]
     (let [runtime (gensym "runtime")
           runtime-options (create-partial-runtime-options project args)
-          glue-paths (vec (.glue runtime-options))
-          feature-paths (vec (.featurePaths runtime-options))
+          glue-paths (vec (.getGlue runtime-options))
+          feature-paths (vec (.getFeaturePaths runtime-options))
           target-path (:target-path project)
           project (project/merge-profiles project [:test])]
       (eval-in-project
        (-> project
            (update-in [:dependencies] conj
-                      ['lein-cucumber "1.0.2"]
-                      ['info.cukes/cucumber-clojure "1.1.1"])
+                      ['lein-cucumber "1.0.3"]
+                      ['info.cukes/cucumber-clojure "1.1.6"])
            (update-in [:source-paths] (partial apply conj) glue-paths))
        `(do
           (let [~runtime (leiningen.cucumber.util/run-cucumber! ~feature-paths ~glue-paths ~target-path ~(vec args))]

--- a/src/leiningen/cucumber.clj
+++ b/src/leiningen/cucumber.clj
@@ -33,8 +33,8 @@
       (eval-in-project
        (-> project
            (update-in [:dependencies] conj
-                      ['lein-cucumber "1.0.3"]
-                      ['info.cukes/cucumber-clojure "1.1.6"])
+                      ['org.clojars.punkisdead/lein-cucumber "1.0.4"]
+                      ['info.cukes/cucumber-clojure "1.2.0"])
            (update-in [:source-paths] (partial apply conj) glue-paths))
        `(do
           (let [~runtime (leiningen.cucumber.util/run-cucumber! ~feature-paths ~glue-paths ~target-path ~(vec args))]

--- a/src/leiningen/cucumber/util.clj
+++ b/src/leiningen/cucumber/util.clj
@@ -1,22 +1,16 @@
 (ns leiningen.cucumber.util
   (:use [clojure.java.io])
   (:import [cucumber.runtime.clj Backend])
-  (:import [cucumber.runtime.formatter FormatterFactory])
   (:import [cucumber.runtime.io MultiLoader])
   (:import [cucumber.runtime.model CucumberFeature])
   (:import [cucumber.runtime RuntimeOptions CucumberException]))
 
 (defn- create-runtime-options [feature-paths glue-paths target-path args]
-  (let [runtime-options (RuntimeOptions. (vec args))
-        formatter-factory (FormatterFactory.)]
+  (let [runtime-options (RuntimeOptions. (vec args))]
     (when (.. runtime-options (getFeaturePaths) (isEmpty))
       (.. runtime-options (getFeaturePaths) (addAll feature-paths)))
     (when (.. runtime-options (getGlue) (isEmpty))
       (.. runtime-options (getGlue) (addAll glue-paths)))
-    (.addFormatter runtime-options (.create formatter-factory (str "pretty:"
-                                                                   (.getAbsolutePath (file target-path
-                                                                                           "test-reports"
-                                                                                           "cucumber.out")))))
     runtime-options))
 
 

--- a/src/leiningen/cucumber/util.clj
+++ b/src/leiningen/cucumber/util.clj
@@ -1,37 +1,38 @@
 (ns leiningen.cucumber.util
   (:use [clojure.java.io])
+  (:import [cucumber.runtime.clj Backend])
   (:import [cucumber.runtime.formatter FormatterFactory])
-  (:import [cucumber.runtime.io FileResourceLoader])
+  (:import [cucumber.runtime.io MultiLoader])
   (:import [cucumber.runtime.model CucumberFeature])
   (:import [cucumber.runtime RuntimeOptions CucumberException]))
 
 (defn- create-runtime-options [feature-paths glue-paths target-path args]
-  (let [runtime-options (RuntimeOptions. (java.util.Properties.)
-                                         (into-array String args))
+  (let [runtime-options (RuntimeOptions. (vec args))
         formatter-factory (FormatterFactory.)]
-    (when (.. runtime-options featurePaths (isEmpty))
-      (.. runtime-options featurePaths (addAll feature-paths)))
-    (when (.. runtime-options glue (isEmpty))
-      (.. runtime-options glue (addAll glue-paths)))
-    (doto (.formatters runtime-options)
-      (.add (.create formatter-factory (str "pretty:"
-                                            (.getAbsolutePath (file target-path
-                                                                    "test-reports"
-                                                                    "cucumber.out"))))))
+    (when (.. runtime-options (getFeaturePaths) (isEmpty))
+      (.. runtime-options (getFeaturePaths) (addAll feature-paths)))
+    (when (.. runtime-options (getGlue) (isEmpty))
+      (.. runtime-options (getGlue) (addAll glue-paths)))
+    (.addFormatter runtime-options (.create formatter-factory (str "pretty:"
+                                                                   (.getAbsolutePath (file target-path
+                                                                                           "test-reports"
+                                                                                           "cucumber.out")))))
     runtime-options))
+
 
 (defn- create-runtime [runtime-options]
   (let [classloader (.getContextClassLoader (Thread/currentThread))
-        resource-loader (FileResourceLoader.)]
-    (cucumber.runtime.Runtime. resource-loader classloader runtime-options)))
+        resource-loader (MultiLoader. classloader)
+        backend (Backend. resource-loader)]
+    (cucumber.runtime.Runtime. resource-loader classloader [backend] runtime-options)))
 
 (defn run-cucumber! [feature-paths glue-paths target-path args]
   (let [runtime-options (create-runtime-options feature-paths glue-paths
                                                 target-path args)
         runtime (create-runtime runtime-options)]
     (println "Running cucumber...")
-    (println "Looking for features in: " (vec (.featurePaths runtime-options)))
-    (println "Looking for glue in: " (vec (.glue runtime-options)))
+    (println "Looking for features in: " (vec (.getFeaturePaths runtime-options)))
+    (println "Looking for glue in: " (vec (.getGlue runtime-options)))
     (try
       (.run runtime)
       (catch CucumberException e


### PR DESCRIPTION
This upgrades the cucumber-clojure dependency to the latest version. The latest cucumber-clojure version includes some fixes to add tagged Before/After hooks in clojure.
